### PR TITLE
Added timeout for tweets and improved documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ These users helped me improve this script.
 
 ### Installing Dependencies
 
-All three dependencies can be installed you Python's package manager, [pip](https://pip.pypa.io/en/stable/installing/)
+All three dependencies can be installed you Python's package manager, [pip](https://pip.pypa.io/en/stable/installing/).
+
 Once you have pip installed, you can install three dependencies with
 
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ These users helped me improve this script.
 # Installation
 ## Part A - Downloading the files
 
+### Installing Dependencies
+
+All three dependencies can be installed you Python's package manager, [pip](https://pip.pypa.io/en/stable/installing/)
+Once you have pip installed, you can install three dependencies with
+
+```
+pip install pyspeedtest tweepy pyyaml
+```
+
+### Installing CmonOptus
+
 #### Option 1 - Downloading here
 Simply press the download button on this page, then proceed to press 'Download as ZIP'.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Simply press the download button on this page, then proceed to press 'Download a
 1. In that /CmonOptus/ folder there is a file named 'config.yaml', open up this file in your favorite text editor and alter the values as needed.
 2. Use the values that we got from the last part to fill the first four rows.
 3. The ```check_interval``` value should be how often you want the software to run the speed test in seconds (the software randomly generates a time between check_interval*0.75 and check_interval*1.25, to look more legitimate).
+4. The ```timeout_interval``` value will set a hard limit on how often CmonOptus can tweet. For example, it has a default of no more than once every hour (3600 seconds).
+5. The ```paid_upload_speed``` and ```paid_download_speed``` should be the internet speed promised in your contract, in Mb/s.
 
 ## Part D - Running the app.
 #### Option A - Simple

--- a/User.py
+++ b/User.py
@@ -63,8 +63,8 @@ if __name__ == "__main__":
     previous_tweet_time = None
 
     while True:
+        upload, download = collectConnectionStatistics()
         if not isTimedOut(details['timeout_interval'], previous_tweet_time):
-            upload, download = collectConnectionStatistics()
             if download < details['paid_download_speed']*0.75:
                 previous_tweet_time = datetime.now()
                 sendTweet(upload, download, details, auth)

--- a/config.yaml
+++ b/config.yaml
@@ -3,5 +3,6 @@ consumer_secret: CONSUMER_SECRET
 access_key: ACCESS_KEY
 access_secret: ACCESS_SECRET
 check_interval: TIME_IN_SECONDS
+timeout_interval: 3600
 paid_upload_speed: EXPECTED_UPLOAD
 paid_download_speed: EXPECTED_DOWNLOAD


### PR DESCRIPTION
### Documentation
A guide for pip installation is now included with the README, as per suggestion from #2 

### Timeout
There is now an automatic timeout for tweets to prevent a large barrage of tweets being sent in a short time span. It does not interrupt the regular speed tests, as you may want to start logging this data the sake of for posterity

#### Going Forward
You may want to consider following a style guide, such as [PEP-8](https://www.python.org/dev/peps/pep-0008/) or [Google](https://google.github.io/styleguide/pyguide.html)

Outside of that, your project looks pretty good! Keep up the coding!